### PR TITLE
use _.extend on options in toc.add() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,8 +128,9 @@ toc.insert = function(str, options) {
 
 // Read a file and add a TOC, dest is optional.
 toc.add = function(src, dest, options) {
+  var opts = _.extend({clean: ['docs']}, options)
   var content = file.readFileSync(src);
   if (utils.isDest(dest)) {options = dest; dest = src;}
-  file.writeFileSync(dest, toc.insert(content, {clean: ['docs']}));
+  file.writeFileSync(dest, toc.insert(content, opts));
   console.log(chalk.green('>> Success:'), dest);
 };


### PR DESCRIPTION
This makes the options passed to toc.add() continue on to toc.insert().
