### PR TITLE
Ensure toc comments have newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,8 @@ toc.raw = function(str, options) {
 
 
 toc.insert = function(str, options) {
-  var start = '<!-- toc -->\n';
-  var stop  = '\n<!-- toc stop -->';
+  var start = '<!-- toc -->';
+  var stop  = '<!-- toc stop -->';
   var strip = /<!-- toc -->[\s\S]+<!-- toc stop -->/;
 
   var content = matter(str).content;
@@ -119,7 +119,7 @@ toc.insert = function(str, options) {
   content = content.replace(strip, start);
 
   // Generate the new TOC
-  var table = start + toc(content, options) + stop;
+  var table = '\n\n' + start + '\n\n' + toc(content, options) + '\n' + stop + '\n';
   return front + content.replace(start, table);
 };
 

--- a/test/fixtures/extra-comment.md
+++ b/test/fixtures/extra-comment.md
@@ -1,0 +1,9 @@
+# Contains extra comment
+
+<!-- toc -->
+
+## Hello world
+
+<!-- Extra comment -->
+
+Hi

--- a/test/fixtures/tocstop.md
+++ b/test/fixtures/tocstop.md
@@ -1,0 +1,7 @@
+# Contains toc stop comment
+
+<!-- toc -->
+<!-- toc stop -->
+## Hello world
+
+Hi

--- a/test/test.js
+++ b/test/test.js
@@ -8,8 +8,11 @@
 
 'use strict';
 
+var assert = require('chai').assert;
 var expect = require('chai').expect;
 var file = require('fs-utils');
+var marked = require('marked');
+var _ = require('lodash');
 var toc  = require('../index');
 
 var strip = function(str) {
@@ -64,5 +67,25 @@ describe('toc', function () {
     //   '* [License](#license)'
     // ].join('\n');
     // expect(strip(actual)).to.eql(strip(expected));
+  });
+
+  it('should allow toc stop comment in text.', function () {
+    var fixture = file.readFileSync('test/fixtures/tocstop.md');
+    actual = toc.insert(fixture);
+    var tokens = marked.lexer(actual);
+    var htmlTokens = _.filter(tokens, function (token) { return token.type == 'html' });
+    assert.propertyVal(htmlTokens[0], 'text', '<!-- toc -->\n\n');
+    assert.propertyVal(htmlTokens[1], 'text', '<!-- toc stop -->\n\n');
+  });
+
+  it('should handle extra comments in text.', function() {
+    var fixture = file.readFileSync('test/fixtures/extra-comment.md');
+    actual = toc.insert(fixture);
+    var tokens = marked.lexer(actual);
+    var htmlTokens = _.filter(tokens, function (token) { return token.type == 'html' });
+    assert.propertyVal(htmlTokens[0], 'text', '<!-- toc -->\n\n');
+    // Contains 3 newlines since we don't strip newlines around initial toc comment
+    assert.propertyVal(htmlTokens[1], 'text', '<!-- toc stop -->\n\n\n');
+    assert.propertyVal(htmlTokens[2], 'text', '<!-- Extra comment -->\n\n');
   });
 });


### PR DESCRIPTION
If they’re not properly surrounded by newlines, marked parses following text as part of the html block, not as markdown. This can cause the TOC not to render.
