### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ var result = toc(str, {filter: removeYunk});
 ```
 
 
-### options.bullet
+### options.bullets
 
 Type: `String|Array`
 


### PR DESCRIPTION
Fix typo, `options.bullets` rather than `options.bullet` which has no effect on the output.