### PR TITLE
options.maxdepth is broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,13 +134,15 @@ function bullets(arr, options) {
     if (fn && !fn(ele.content, ele, arr)) {
       continue;
     }
+    
+    if (ele.lvl > opts.maxdepth) {
+      continue;
+    }
 
     var lvl = ele.lvl - opts.highest;
     res.push(listitem(lvl, ele.content, opts));
 
-    if (ele.lvl === opts.maxdepth) {
-      break;
-    }
+    
   }
   return res.join('\n');
 }


### PR DESCRIPTION
When you specify 'maxdepth' in options it will stop adding any headers to the TOC once it encounters one that has the specified maxdepth.

Example Markdown:
```
# Heading 1
## Heading 2
### Heading 3
# Heading4
```

Running `toc(str, {maxdepth: 2}).content` (with str being the example markdown) will produce:
`'- [Heading 1](#heading-1)\n  * [Heading 2](#heading-2)'`
it should be:
`'- [Heading 1](#heading-1)\n  * [Heading 2](#heading-2)\n- [Heading4](#heading4)'`

This change should fix the issue.