### PR TITLE
Fix slug generation of headlines including colons (:)

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function bullets(arr, options) {
     if (fn && !fn(ele.content, ele, arr)) {
       continue;
     }
-    
+
     if (ele.lvl > opts.maxdepth) {
       continue;
     }
@@ -142,7 +142,7 @@ function bullets(arr, options) {
     var lvl = ele.lvl - opts.highest;
     res.push(listitem(lvl, ele.content, opts));
 
-    
+
   }
   return res.join('\n');
 }
@@ -209,6 +209,7 @@ function slugify(str, opts) {
   }
 
   str = str.split('.').join('').toLowerCase();
+  str = str.split(':').join('');
   str = str.split(' ').join('-');
   str = str.split(/\t/).join('----');
   return str.replace(/[^a-z0-9]/g, '-');

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,15 @@ describe('toc', function() {
     ].join('\n'));
   });
 
+  it('should handle dots, colons and dashes correctly:', function() {
+    toc('# AAA:aaa\n# BBB.bbb\n# CCC-ccc\nfoo\nbar\nbaz').content.should.equal([
+      '- [AAA:aaa](#aaaaaa)',
+      '- [BBB.bbb](#bbbbbb)',
+      '- [CCC-ccc](#ccc-ccc)'
+    ].join('\n'));
+  });
+
+
   it('should use a different bullet for each level', function() {
     toc(read('test/fixtures/levels.md')).content.should.equal([
       '- [AAA](#aaa)',


### PR DESCRIPTION
Fix for https://github.com/jonschlinkert/markdown-toc/issues/49