### PR TITLE
Correct documentation for command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage: markdown-toc [--json] [-i] <input>
 
   --json: Print the TOC in json format
 
-  -i:     Edit the <input> file directly, injecting the TOC at - [Highights](#highights)
+  -i:     Edit the <input> file directly, injecting the TOC at  <!-- toc -->
 - [Usage](#usage)
 - [API](#api)
 - [toc.plugin](#tocplugin)


### PR DESCRIPTION
The readme was still pointing to - highight instead of  <!-- toc --> as text replacement for the ToC.