### PR TITLE
Made fix to avoid crashing on empty headers. Added corresponding test.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function generate(options) {
       var alen = arr.length, j = 0;
       while (alen--) {
         var tok = arr[j++];
-        if (tok.lines[0] > tocstart) {
+        if (tok.lines && (tok.lines[0] > tocstart)) {
           if (!seen.hasOwnProperty(tok.content)) {
             seen[tok.content] = 0;
           } else {

--- a/test/test.js
+++ b/test/test.js
@@ -135,6 +135,13 @@ describe('toc', function() {
     ].join('\n'));
   });
 
+  it('should allow and ignore empty headings:', function() {
+    toc('#\n# \n# AAA\n# BBB\nfoo\nbar\nbaz#\n').content.should.equal([
+      '- [AAA](#aaa)',
+      '- [BBB](#bbb)'
+    ].join('\n'));
+  });
+
   it('should handle dots, colons dashes and underscores correctly:', function() {
     toc('# AAA:aaa\n# BBB.bbb\n# CCC-ccc\n# DDD_ddd\nfoo\nbar\nbaz').content.should.equal([
       '- [AAA:aaa](#aaaaaa)',


### PR DESCRIPTION
Hello

Empty heading (e.g. "# ") causes the parser to crash. This fixes it.

Note: I see people using empty headers as placeholders, which why I ran into the problem.

Thanks

-lu22do