### PR TITLE
Added support for a 'slugending' option for customizing duplicate slugs handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Generate a markdown TOC (table of contents) with Remarkable.
   * [options.append](#optionsappend)
   * [options.filter](#optionsfilter)
   * [options.slugify](#optionsslugify)
+  * [options.slugending](#optionsslugending)
   * [options.bullets](#optionsbullets)
   * [options.maxdepth](#optionsmaxdepth)
   * [options.firsth1](#optionsfirsth1)
@@ -241,6 +242,22 @@ Default: Basic non-word character replacement.
 
 ```js
 var str = toc('# Some Article', {slugify: require('uslug')});
+```
+
+### options.slugending
+
+Type: `Function`
+
+Default: Adds a "-1" suffix at the end of the slug of the first duplicate and increases it for each new one.
+
+Allows to change default behavior when finding a duplicate slug (i.e. a heading with the same text as another heading). This is useful when using other TOC tool that behave differently when treating duplicate slugs.
+
+**Example**
+
+```js
+var str = toc('# Some Article # Some Article', {slugending: function(str, seen, opts) {
+  return str + '-' + (seen + 1);  // starts at '-2' for first duplicate slug rather than '-1'
+}});
 ```
 
 ### options.bullets

--- a/index.js
+++ b/index.js
@@ -203,7 +203,12 @@ function slugify(str, options, token) {
   str = str.split(/[|$&`~=\\\/@+*!?({[\]})<>=.,;:'"^]/).join('');
   if (token && typeof token === 'object' && token.seen) {
     if (token.seen > 0) {
-      str += '-' + token.seen;
+      if (opts && typeof opts.slugending === 'function') {
+        str = opts.slugending(str, token.seen, opts);
+      }
+      else {
+        str += '-' + token.seen;
+      }
     }
   }
   return str;

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,18 @@ describe('options: custom functions:', function() {
     actual.content.should.equal('- [Some Article](#!Some-Article!)');
   });
 
+  it('should allow a custom slugending function for duplicate hendings to be passed:', function() {
+    var actual = toc('# Overview\n# Overview', {
+      slugending: function(str, seen, opts) {
+       return str + '-' + (seen + 1);  // starts at '-2' for first duplicate slug rather than '-1'
+      }
+    });
+    actual.content.should.equal([
+      '- [Overview](#overview)',
+      '- [Overview](#overview-2)'
+    ].join('\n'));
+  });
+
   it('should strip forward slashes in slugs', function() {
     var actual = toc('# Some/Article');
     actual.content.should.equal('- [Some/Article](#somearticle)');


### PR DESCRIPTION
Hello

I use markdown-toc's parser in correlation with another toc tool (markdown-it-anchor) and the way the duplicate heading are treated is not consistant. markdown-toc starts by adding a '-1' suffix to the first duplicate heading's slug while the other one adds a '-2' suffix (since it is the second identical heading, I guess). I thought that the best way to solve this is to allow people to customize the slug ending in case of duplicate heading. This is what this change consists of.

Thanks

-lu22do