### PR TITLE
Added test for duplicate headers in json output

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -339,6 +339,7 @@ describe('json property', function() {
     toc('# AAA\n## BBB\n### CCC\n#### DDD').json[0].should.have.property('content', 'AAA');
     toc('## BBB\n### CCC\n#### DDD').json[2].should.have.property('content', 'DDD');
     toc('### CCC\n#### DDD').json[0].should.have.property('content', 'CCC');
+    toc('### AAA\n### AAA').json[1].should.have.property('slug', 'aaa-1'); // duplicate headers
   });
 });
 


### PR DESCRIPTION
This test used to pass but with recent commit 61f78ad33f80cf8bde9d4a9666fbcbf26a9e08f4 stops passing due to this code:

```
  if (token && typeof token === 'object' && token.seen) {       
     if (token.seen > 0) {      
       str += '-' + token.seen;     
     }      
   }        
```

being removed from the default slugify function. 

Is it on oversight or a conscious decision?

Thanks

-Ludo
