### PR TITLE
add slug prefix

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -206,6 +206,14 @@ Default: Basic non-word character replacement.
 var str = toc('# Some Article', {slugify: require('uslug')});
 ```
 
+### options.slug_prefix
+
+Type: `String`
+
+Default: ``
+
+Adds `options.slug_prefix` to generated slug. Useful when there is no support in-document anchors and slugs are generated with prefixes.
+
 ### options.bullets
 
 Type: `String|Array`

--- a/cli.js
+++ b/cli.js
@@ -4,22 +4,31 @@ var fs = require('fs');
 var toc = require('./index.js');
 var utils = require('./lib/utils');
 var args = utils.minimist(process.argv.slice(2), {
-  boolean: ['i', 'json']
+  boolean: ['i', 'json'],
+  string: ['slug-prefix']
 });
 
 if (args._.length !== 1) {
   console.error([
-    'Usage: markdown-toc [--json] [-i] <input> ',
+    'Usage: markdown-toc [--json] [-i] [--slug-prefix <prefix>] <input> ',
     '',
-    '  input:  The markdown file to parse for table of contents,',
+    '  input:   The markdown file to parse for table of contents,',
     '          or "-" to read from stdin.',
     '',
     '  --json: Print the TOC in json format',
     '',
     '  -i:     Edit the <input> file directly, injecting the TOC at <!-- toc -->',
-    '          (Without this flag, the default is to print the TOC to stdout.)'
+    '          (Without this flag, the default is to print the TOC to stdout.)',
+    '',
+    '  --slug-prefix <prefix>:',
+    '          Add <prefix> to the generated slugs.'
   ].join('\n'));
   process.exit(1);
+}
+
+if (!args.i && !args.json) {
+    console.error('markdown-toc: you must specify either --json or -i');
+    process.exit(1);
 }
 
 if (args.i && args.json) {
@@ -36,11 +45,16 @@ var input = process.stdin;
 if (args._[0] !== '-') input = fs.createReadStream(args._[0]);
 
 input.pipe(utils.concat(function(input) {
+  options = {};
+  if (args['slug-prefix']) {
+    options['slug_prefix'] = args['slug-prefix'];
+  }
+
   if (args.i) {
-    var newMarkdown = toc.insert(input.toString());
+    var newMarkdown = toc.insert(input.toString(), options);
     fs.writeFileSync(args._[0], newMarkdown);
   } else {
-    var parsed = toc(input.toString());
+    var parsed = toc(input.toString(), options);
     output(parsed);
   }
 }));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,6 +70,11 @@ utils.slugify = function(str, options) {
   if (options.num) {
     str += '-' + options.num;
   }
+
+  if (options.slug_prefix) {
+    str = options.slug_prefix + str;
+  }
+
   return str;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -269,6 +269,14 @@ describe('toc', function() {
     ].join('\n'));
   });
 
+  it('should add a slug prefix, if defined:', function() {
+    assert.equal(toc('# AAA\n# BBB\n# CCC\nfoo\nbar\nbaz', {slug_prefix: 'test-'}).content, [
+      '- [AAA](#test-aaa)',
+      '- [BBB](#test-bbb)',
+      '- [CCC](#test-ccc)'
+    ].join('\n'));
+  });
+
   it('should rotate bullets when there are more levels than bullets defined:', function() {
     var actual = toc('# AAA\n## BBB\n### CCC', {
       bullets: ['?']


### PR DESCRIPTION
I have [vim-plugin](https://github.com/mgor/vim-markdown-grip) that uses `markdown-toc` to generate table of contents that I have been using for markdown files in github projects. Now however, I'm working on a project that is hosted on bitbucket. The markdown "engine" in bitbucket adds `markdown-header-` to the generated slugs in markdown documents, due to this the links in `markdown-toc` generated table of content does not work.

Since `cli.json` didn't have any support for options, and that there was only a small part of `utils.slugify` that needed modification, I added a new option and support for that option in `cli.json`:

- new option for adding prefixes to generated slugs.
- added support in cli.js 
- added test for slug prefixes.