### PR TITLE
Fixes for Angular Cli (>2.x)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,25 +5,24 @@
  */
 
 var diacritics = require('diacritics-map');
-var utils = require('lazy-cache')(require);
+/*var utils = require('lazy-cache')(require);
 var fn = require;
-require = utils;
+require = utils;*/
 
 /**
  * Lazily required module dependencies
  */
 
-require('concat-stream', 'concat');
-require('gray-matter', 'matter');
-require('list-item', 'li');
-require('markdown-link', 'mdlink');
-require('minimist');
-require('mixin-deep', 'merge');
-require('object.pick', 'pick');
-require('remarkable', 'Remarkable');
-require('repeat-string', 'repeat');
-require('strip-color');
-require = fn;
+utils.concat = require('concat-stream');
+utils.matter = require('gray-matter');
+utils.li = require('list-item');
+utils.mdlink = require('markdown-link');
+utils.minimist = require('minimist');
+utils.merge = require('mixin-deep');
+utils.pick = require('object.pick');
+utils.Remarkable = require('remarkable');
+utils.repeat = require('repeat-string');
+utils.stripColor = require('strip-color');
 
 /**
  * Get the "title" from a markdown link

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,12 +5,10 @@
  */
 
 var diacritics = require('diacritics-map');
-/*var utils = require('lazy-cache')(require);
-var fn = require;
-require = utils;*/
+
 
 /**
- * Lazily required module dependencies
+ * Required module dependencies
  */
 var utils = new Object();
 utils.concat = require('concat-stream');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@ require = utils;*/
 /**
  * Lazily required module dependencies
  */
-
+var utils = new Object();
 utils.concat = require('concat-stream');
 utils.matter = require('gray-matter');
 utils.li = require('list-item');

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "minimist": "^1.2.0",
     "mixin-deep": "^1.1.3",
     "object.pick": "^1.2.0",
+    "querystring-es3": "^0.2.1",
     "remarkable": "^1.7.1",
     "repeat-string": "^1.6.1",
     "strip-color": "^0.1.0"
@@ -123,5 +124,8 @@
   },
   "directories": {
     "test": "test"
+  },
+  "browser": {
+    "querystring": "querystring-es3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "minimist": "^1.2.0",
     "mixin-deep": "^1.1.3",
     "object.pick": "^1.2.0",
-    "querystring-es3": "^0.2.1",
+    "querystring-es3": "git+https://github.com/SpainTrain/querystring-es3.git",
     "remarkable": "^1.7.1",
     "repeat-string": "^1.6.1",
     "strip-color": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "concat-stream": "^1.5.2",
     "diacritics-map": "^0.1.0",
-    "gray-matter": "^2.1.0",
+    "gray-matter": "^3.1.1",
     "lazy-cache": "^2.0.2",
     "list-item": "^1.1.1",
     "markdown-link": "^0.1.1",


### PR DESCRIPTION
Note: [querystring-es3](https://github.com/SpainTrain/querystring-es3) v1.0.0 still hasn't released to NPM. Issue SpainTrain/querystring-es3#6 requests it be released. 

Not sure how you want to work in these fixes @doowb; however, until querystring-es3 new version is released, I would wait on it.