### PR TITLE
Add support for loading custom slugs from HTML name attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ function linkify(tok, options) {
     var text = titleize(tok.content, opts);
     var slug = utils.slugify(tok.content, opts);
     slug = querystring.escape(slug);
+    slug = slug.split("(").join("%28").split(")").join("%29");
     if (opts && typeof opts.linkify === 'function') {
       return opts.linkify(tok, text, slug, opts);
     }
@@ -212,9 +213,9 @@ function titleize(str, opts) {
   if (opts && typeof opts.titleize === 'function') {
     return opts.titleize(str, opts);
   }
-  str = utils.getTitle(str);
   str = str.split(/<\/?[^>]+>/).join('');
   str = str.split(/[ \t]+/).join(' ');
+  str = utils.getTitle(str);
   return str.trim();
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,6 +54,11 @@ utils.slugify = function(str, options) {
     return options.slugify(str, options);
   }
 
+  var tagMatch = /^\s*<[^>]+ name="([^"]+)"/.exec(str);
+  if (tagMatch !== null) {
+    return tagMatch[1];
+  }
+
   str = utils.getTitle(str);
   str = utils.stripColor(str);
   str = str.toLowerCase();


### PR DESCRIPTION
This PR allows users to specify custom slugs in header contents instead of using GFM's automatic slugs. For example, this header:

`### <a span="foo" href="somefile.js#45">foobar()</a>`

Would have a TOC line with a link to `#foo`.

I can and will write tests for this, but before going through that I just wanted to ask if this would be an acceptable feature.