### PR TITLE
Should strip out links and html on headings

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,7 +37,7 @@ if (args._.length !== 1) {
     '',
     '  --no-stripHeadingTags: Do not strip extraneous HTML tags from heading',
     '                         text before slugifying',
-    '',  
+    '',
     '  --indent:     Provide the indentation to use - defaults to \'  \'',
     '                (to specify a tab, use the bash-escaped $\'\\t\')'
   ].join('\n'));
@@ -74,5 +74,5 @@ input.on('error', function onErr(err) {
 
 function output(parsed) {
   if (args.json) return console.log(JSON.stringify(parsed.json, null, '  '));
-  process.stdout.write(parsed.content);
+  process.stdout.write(parsed.content+'\n');
 }

--- a/index.js
+++ b/index.js
@@ -187,13 +187,37 @@ function linkify(tok, options) {
     opts.num = tok.seen;
     var text = titleize(tok.content, opts);
     var slug = utils.slugify(tok.content, opts);
-    slug = querystring.escape(slug);
+
+    var new_text = clearToken(text, '[');
+    var new_slug = clearToken(slug, '#');
+    new_slug = querystring.escape(new_slug);
     if (opts && typeof opts.linkify === 'function') {
-      return opts.linkify(tok, text, slug, opts);
+      return opts.linkify(tok, new_text, new_slug, opts);
     }
-    tok.content = utils.mdlink(text, '#' + slug);
+    tok.content = utils.mdlink(new_text, '#' + new_slug);
   }
   return tok;
+}
+
+/**
+ * Removes a given token from the string returning the new value.
+ *
+ * @param  {[String]} token
+ * @param  {[String]} delimiter
+ * @return {[String]} cleaned token
+ */
+
+function clearToken(token, delimiter) {
+  var new_token
+  if(token.indexOf(delimiter) != -1) {
+    new_token = token.substring(0, token.lastIndexOf(delimiter)).trim();
+  }
+  else {
+    new_token = token
+  }
+  // console.log('Before: ' + token)
+  // console.log('After : ' + new_token)
+  return new_token
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -188,13 +188,13 @@ function linkify(tok, options) {
     var text = titleize(tok.content, opts);
     var slug = utils.slugify(tok.content, opts);
 
-    var new_text = clearToken(text, '[');
-    var new_slug = clearToken(slug, '#');
-    new_slug = querystring.escape(new_slug);
+    var slug = clearToken(slug, '#');
+    var text = stripMarkdownLink(text);
+    slug = querystring.escape(slug);
     if (opts && typeof opts.linkify === 'function') {
-      return opts.linkify(tok, new_text, new_slug, opts);
+      return opts.linkify(tok, text, slug, opts);
     }
-    tok.content = utils.mdlink(new_text, '#' + new_slug);
+    tok.content = utils.mdlink(text, '#' + slug);
   }
   return tok;
 }
@@ -202,9 +202,9 @@ function linkify(tok, options) {
 /**
  * Removes a given token from the string returning the new value.
  *
- * @param  {[String]} token
- * @param  {[String]} delimiter
- * @return {[String]} cleaned token
+ * @param  {String} token
+ * @param  {String} delimiter
+ * @return {String} cleaned token
  */
 
 function clearToken(token, delimiter) {
@@ -218,6 +218,21 @@ function clearToken(token, delimiter) {
   // console.log('Before: ' + token)
   // console.log('After : ' + new_token)
   return new_token
+}
+
+/**
+ * Regex match markdown link
+ * https://stackoverflow.com/questions/37462126/regex-match-markdown-link
+ *
+ * @param  {String} text
+ * @return {String} stripped text
+ */
+function stripMarkdownLink(text) {
+  // var str = String(text).replace(/__|\*|\#|(?:\[([^\]]*)\]\([^)]*\))/gm, '$1').trim();
+  var str = String(text).replace(/__|\*|\#|(?:\[([^\]]*)\]\([^)]*\))/gm, '').trim();
+  // console.log('Before: ' + text)
+  // console.log('After : ' + str)
+  return str;
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -344,6 +344,11 @@ describe('toc', function() {
       '- [ddd](#fez-ddd)'
     ].join('\n'));
   });
+
+  it('should strip out links and html on headings', function() {
+    assert.equal(toc('## Title <sub>[Go](#ite)</sub>').content, '- [Title](#title-go)');
+    assert.equal(toc('## Title <sub>[Go]</sub>').content, '- [Title [Go]](#title-go)');
+  });
 });
 
 describe('toc tokens', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -128,6 +128,7 @@ describe('options: custom functions:', function() {
         return str.indexOf('...') === -1;
       }
     });
+    // console.log('actual.content: \n' + actual.content)
     assert.equal(actual.content, [
       '- [AAA](#aaa)',
       '  * [a.1](#a1)',


### PR DESCRIPTION
```
> mocha



  plugin
    √ should work as a remarkable plugin (110ms)

  options: custom functions:
    √ should allow a custom `strip` function to strip words from heading text:
    √ should allow a custom slugify function to be passed:
    √ should strip forward slashes in slugs
    √ should strip backticks in slugs
    √ should strip CJK punctuations in slugs
    √ should strip & in slugs
    √ should escape the CJK characters in linkify
    √ should strip HTML tags from headings
    √ should not strip HTML tags from headings when `stripHeadingTags` is false
    √ should condense spaces in the heading text
    √ should replace spaces in links with dashes
    √ should allow a `filter` function to filter out unwanted bullets:

  toc
    √ should generate a TOC from markdown headings:
    √ should allow duplicate headings:
    √ should increment duplicate headings:
    √ should allow and ignore empty headings:
    √ should handle dots, colons dashes and underscores correctly:
    √ should use a different bullet for each level
    √ should use a different bullet for each level
    √ should handle mixed heading levels:
    √ should ignore headings in fenced code blocks.
    √ should allow `maxdepth` to limit heading levels:
    √ should remove the first H1 when `firsth1` is false:
    - should correctly calculate `maxdepth` when `firsth1` is false:
    √ should allow custom bullet points to be defined:
    √ should rotate bullets when there are more levels than bullets defined:
    √ should rotate bullets when there are more levels than bullets defined:
    √ should wrap around the bullet point array
    √ should allow custom bullet points at different depths
    √ should remove diacritics from the links
    √ should strip words from heading text, but not from urls:
    √ should strip out links and html on headings

  toc tokens
    √ should return an object for customizing a toc:
    √ should return the `highest` heading level in the TOC:
    √ should return an array of tokens:
    √ should expose the `lvl` property on headings tokens:

  json property
    √ should expose a `json` property:
    √ should return the `content` property for a heading:

  toc.insert
    √ should retain trailing newlines in the given string
    √ should insert a markdown TOC beneath a `<!-- toc -->` comment. (115ms)
    √ should replace an old TOC between `<!-- toc -->...<!-- tocstop -->` comments.
    √ should insert the toc passed on the options.
    √ should accept options
    √ should accept no links option


  44 passing (289ms)
  1 pending
```