### PR TITLE
Updates gray matter to remove dependency on coffee script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "concat-stream": "^1.5.2",
     "diacritics-map": "^0.1.0",
-    "gray-matter": "^3.1.1",
+    "gray-matter": "^4.0.0",
     "lazy-cache": "^2.0.2",
     "list-item": "^1.1.1",
     "markdown-link": "^0.1.1",


### PR DESCRIPTION
Hi there! I was a littler surprised to find an entire programming language in my dependency tree when I wanted some markdown parsing 🍡 

![Screen Shot 2019-11-30 at 7 01 51 AM](https://user-images.githubusercontent.com/49038/69900295-69602f00-133f-11ea-966b-0e9186168abd.png)

After a bit of digging I found that it was [removed from gray-matter back in 2017](https://github.com/jonschlinkert/gray-matter/blob/master/CHANGELOG.md#300---2017-06-30) and figured I'd go through the dependency tree updating the deps.