### PR TITLE
adds arch linux specific install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Install with [npm](https://www.npmjs.com/):
 $ npm install --save markdown-toc
 ```
 
+On [Arch Linux](https://www.archlinux.org/) install the [nodejs-markdown-toc
+AUR package](https://aur.archlinux.org/packages/nodejs-markdown-toc/):
+
+```sh
+pacaur -S nodejs-markdown-toc
+```
+
 ## CLI
 
 ```


### PR DESCRIPTION
I've just added markdown-toc as a package to arch linux and wanted to
share this