### PR TITLE
fix: strip HTML entities like &gt; from slugs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,6 +59,7 @@ utils.slugify = function(str, options) {
   str = str.toLowerCase();
 
   // `.split()` is often (but not always) faster than `.replace()`
+  str = str.split(/&[^;]+;/).join('')
   str = str.split(' ').join('-');
   str = str.split(/\t/).join('--');
   if (options.stripHeadingTags !== false) {

--- a/test/test.js
+++ b/test/test.js
@@ -426,4 +426,8 @@ describe('toc.insert', function() {
     assert.equal(strip(toc.insert(str, { linkify: true })), read('test/expected/insert.md'));
     assert.equal(strip(toc.insert(str, { linkify: false })), read('test/expected/insert-no-links.md'));
   });
+
+  it('should strip HTML entities from slugs', function() {
+    assert.equal(toc('# &lt;div&gt; elements').content, '- [&lt;div&gt; elements](#div-elements)');
+  })
 });


### PR DESCRIPTION
I discovered in my repo https://github.com/vscodeshift/material-ui-snippets that HTML entities like `&gt;` get stripped out of slugs.  Right now in this and other libs, `&lt;div&gt;` gets converted to `lt-div-gt`, but the actual GitHub slug is just `div`.