### PR TITLE
CLI: 'in-place' as mnemonic describing -i switch

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -12,7 +12,7 @@ Usage: markdown-toc [options] <input>
   input:        The Markdown file to parse for table of contents,
                 or "-" to read from stdin.
 
-  -i:           Edit the <input> file directly, injecting the TOC at <!-- toc -->;
+  -i:           Edit input file in-place, injecting the TOC at <!-- toc -->;
                 (Without this flag, the default is to print the TOC to stdout.)
 
   --json:       Print the TOC in JSON format


### PR DESCRIPTION
Maybe 'in-place' easier to grok than 'directly' in description of -i. 