### PR TITLE
Correctly detect frontmatter to avoid mangling document (fixes #180, fixes #189)

### DIFF
--- a/lib/insert.js
+++ b/lib/insert.js
@@ -28,7 +28,7 @@ module.exports = function insert(str, options) {
   if (m) newlines = m[0];
 
   // does the file have front-matter?
-  if (/^---/.test(str)) {
+  if (/^---\n.*\n---\n/.test(str)) {
     // extract it temporarily so the syntax
     // doesn't get mistaken for a heading
     obj = utils.matter(str);

--- a/lib/insert.js
+++ b/lib/insert.js
@@ -50,6 +50,9 @@ module.exports = function insert(str, options) {
     sections.splice(1, 0, open + toc(last, options).content + '\n\n' + close);
   }
 
+  // Trim empty sections to avoid adding newlines to document in join
+  sections = sections.filter((section) => section.length > 0);
+
   var resultString = sections.join('\n\n') + newlines;
   // if front-matter was found, put it back now
   if (obj) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "David Mohl (https://dvcrn.github.io)",
     "Federico Soave (https://github.com/Feder1co5oave)",
     "Gary Green (https://github.com/garygreen)",
+    "Gregory Danielson III (https://gregdan3.dev)",
     "Jon Schlinkert (http://twitter.com/jonschlinkert)",
     "Josh Duff (https://tehshrike.github.io)",
     "Matt Ellis (http://sticklebackplastic.com)",

--- a/test/test.js
+++ b/test/test.js
@@ -426,4 +426,9 @@ describe('toc.insert', function() {
     assert.equal(strip(toc.insert(str, { linkify: true })), read('test/expected/insert.md'));
     assert.equal(strip(toc.insert(str, { linkify: false })), read('test/expected/insert-no-links.md'));
   });
+
+  it('should not mangle a file with an initial horizontal rule', function() {
+    assert.equal(toc.insert('---\nExample\n'),  '---\nExample\n');
+  })
+
 });


### PR DESCRIPTION
The previous format would incorrectly capture:
- A single horizontal rule at the top of the file
- Three literal dashes with arbitrary content after them. This was detected as a frontmatter, and an extra HR would be inserted after as a result.

The new format requires that there are two sets of triple dashes on their own lines, where the first is the first text in the document. This is necessarily the bounding box of a frontmatter, though the inner yml could be invalid and then would appear in the document instead.

There are still two more newline related issues I've noticed:

- An extra newline is inserted between the TOC and content on both top and bottom. This is fairly innocuous.
- ~~If the TOC is first or last item in the document, two spare newlines will be added on the contentless side every generation. Presumably caused by the section being empty but still in the section list.~~ Went ahead and fixed this too!