### PR TITLE
chore: upgrade remarkable dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,10 @@
 environment:
   matrix:
     # node.js
+    - nodejs_version: "22.15.1"
     - nodejs_version: "8.0"
     - nodejs_version: "7.0"
     - nodejs_version: "6.0"
-    - nodejs_version: "5.0"
-    - nodejs_version: "4.0"
-    - nodejs_version: "0.12"
-    - nodejs_version: "0.10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "minimist": "^1.2.0",
     "mixin-deep": "^1.1.3",
     "object.pick": "^1.2.0",
-    "remarkable": "^1.7.1",
+    "remarkable": "^2.0.1",
     "repeat-string": "^1.6.1",
     "strip-color": "^0.1.0"
   },

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
  */
 
 var utils = require('./lib/utils');
+var Remarkable = require('remarkable').Remarkable;
 var querystring = require('querystring');
 
 /**
@@ -26,7 +27,7 @@ module.exports = toc;
  */
 
 function toc(str, options) {
-  return new utils.Remarkable()
+  return new Remarkable()
     .use(generate(options))
     .render(str);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,6 @@ require('markdown-link', 'mdlink');
 require('minimist');
 require('mixin-deep', 'merge');
 require('object.pick', 'pick');
-require('remarkable', 'Remarkable');
 require('repeat-string', 'repeat');
 require('strip-color');
 require = fn;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "markdown-toc": "cli.js"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "test": "mocha"
@@ -56,7 +56,7 @@
     "minimist": "^1.2.0",
     "mixin-deep": "^1.1.3",
     "object.pick": "^1.2.0",
-    "remarkable": "^1.7.1",
+    "remarkable": "^2.0.1",
     "repeat-string": "^1.6.1",
     "strip-color": "^0.1.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var assert = require('assert');
 var inspect = require('util').inspect;
 var utils = require('../lib/utils');
+var Remarkable = require('remarkable').Remarkable;
 var toc = require('..');
 
 function strip(str) {
@@ -18,7 +19,7 @@ function read(fp) {
 describe('plugin', function() {
   it('should work as a remarkable plugin', function() {
     function render(str, options) {
-      return new utils.Remarkable()
+      return new Remarkable()
         .use(toc.plugin(options))
         .render(str);
     }


### PR DESCRIPTION
- upgrades `remarkable` to the latest version, which removes some problematic dependencies causing CVE's to be flagged by automated scanners
- bumps the minimum nodejs version accordingly
- aims to be a minimal change